### PR TITLE
adding process in rebuild script to compile css using compass

### DIFF
--- a/bin/make-install-profile
+++ b/bin/make-install-profile
@@ -1,7 +1,7 @@
 #!/bin/bash
-if [ -z "$1" -o -z "$2" -o -z "$3" ]; then
-  echo "Usage: $0 <machine_name> <Project Name> <Project Description>"
-  echo "Ex: $0 client_xyz \"Web app ABC\" \"Client XYZ's ABC app enables users to browse a database of records.\""
+if [ -z "$1" -o -z "$2" -o -z "$3" -o -z "$4" ]; then
+  echo "Usage: $0 <machine_name> <theme_name> <Project Name> <Project Description>"
+  echo "Ex: $0 client_xyz xyz_foobar \"Web app ABC\" \"Client XYZ's ABC app enables users to browse a database of records.\""
   exit 1
 fi
 
@@ -11,8 +11,9 @@ if [ ! -d os_project ]; then
 fi
 
 NEW="$1"
-PROJECTNAME="$2"
-DESCRIPTION="$3"
+THEME="$2"
+PROJECTNAME="$3"
+DESCRIPTION="$4"
 FILES="os_project.info os_project.install os_project.make os_project.profile"
 DEMOEXTS="deploy_plans.inc features.inc features.uuid_entities.inc info module"
 SEDFLAGS="-i.orig"
@@ -20,6 +21,7 @@ SEDFLAGS="-i.orig"
 # rebuild script
 sed -e "s/PROFILE=\"os_project\"/PROFILE=\"$NEW\"/" $SEDFLAGS bin/rebuild
 sed -e "s/PROJECT/$PROJECTNAME/" $SEDFLAGS bin/rebuild
+sed -e "s/os_theme/$THEME/" $SEDFLAGS bin/rebuild
 
 # deploy script
 sed -e "s/INSTALLPROFILE=os_project/INSTALLPROFILE=$NEW/" $SEDFLAGS bin/deploy_to_test

--- a/bin/rebuild
+++ b/bin/rebuild
@@ -1,18 +1,19 @@
 #!/bin/bash
 #
 # @@ Replace os_project with the actual project name, then remove this line @@
+# @@ Replace os_theme with the intended theme name, then remove this line @@
 #
 # Rebuild os_project in the drupal directory.
 #
 # To use this command you must have `drush make`, `cvs` and `git` installed.
 #
 
-PROFILE="client_xyz"
+PROFILE="os_project"
 # Use Compass to compile CSS from source scss files.
-THEME="xyz_foobar"
+THEME="os_theme"
 
 # Generate a complete Drupal build.
-echo "Building Web app ABC..."
+echo "Building os_project..."
 
 # Remove contrib directories
 DIRECTORIES="drupal
@@ -63,7 +64,5 @@ ln -s ../../$PROFILE $PROFILE
 cd -
 
 # Compile SCSS files into CSS files using Compass.
-# Note that the theme should have a "scss" directory and a "css" directory.
-cd drupal/profiles/$PROFILE/themes/$THEME
-compass compile
-cd -
+# Note that the theme should have a css and scss directory, or a config.rb file.
+compass compile drupal/profiles/$PROFILE/themes/$THEME

--- a/bin/rebuild
+++ b/bin/rebuild
@@ -7,10 +7,12 @@
 # To use this command you must have `drush make`, `cvs` and `git` installed.
 #
 
-PROFILE="os_project"
+PROFILE="client_xyz"
+# Use Compass to compile CSS from source scss files.
+THEME="xyz_foobar"
 
 # Generate a complete Drupal build.
-echo "Building PROJECT..."
+echo "Building Web app ABC..."
 
 # Remove contrib directories
 DIRECTORIES="drupal
@@ -58,4 +60,10 @@ rsync -az drupal/profiles/$PROFILE/ $PROFILE/
 rm -rf drupal/profiles/$PROFILE
 cd drupal/profiles
 ln -s ../../$PROFILE $PROFILE
+cd -
+
+# Compile SCSS files into CSS files using Compass.
+# Note that the theme should have a "scss" directory and a "css" directory.
+cd drupal/profiles/$PROFILE/themes/$THEME
+compass compile
 cd -

--- a/bin/rebuild
+++ b/bin/rebuild
@@ -13,7 +13,7 @@ PROFILE="os_project"
 THEME="os_theme"
 
 # Generate a complete Drupal build.
-echo "Building os_project..."
+echo "Building PROJECT..."
 
 # Remove contrib directories
 DIRECTORIES="drupal


### PR DESCRIPTION
I've modified make-install-profile to add a new <THEMENAME> argument, and modified rebuild script to try and run "compass compile" on the theme's directory (in profiles/PROJECT/themes/THEME)
