### PR TITLE
Move solr into a separate make file

### DIFF
--- a/os_project/os_project.make
+++ b/os_project/os_project.make
@@ -26,6 +26,9 @@ includes[images] = "images.make"
 ; Uncomment to use Panels.
 ;includes[panels] = "panels.make"
 
+; Uncomment to use Solr Search.
+; includes[solr] = "solr.make"
+
 ; OpenSourcery base feature.
 projects[os_base][subdir] = "stock"
 projects[os_base][type] = "module"
@@ -33,13 +36,6 @@ projects[os_base][download][type] = "git"
 projects[os_base][download][url] = "git://github.com/opensourcery/os_base.git"
 projects[os_base][download][branch] = "7.x-1.x"
 projects[os_base][download][tag] = "7.x-1.0"
-
-; Apache Solr Search
-; TODO potentially switch from this module to search_api module.
-; SolrPHPClient is NOT required (all code is in the module).
-; Be sure to use Solr 3.5 or higher. Also remember to copy the module's conf files.
-; http://drupalcode.org/project/apachesolr.git/blob_plain/refs/heads/7.x-1.x:/README.txt
-projects[apachesolr][version] = "1.0-rc3"
 
 ; Follow
 projects[follow][version] = "2.0-alpha1"

--- a/os_project/solr.make
+++ b/os_project/solr.make
@@ -11,6 +11,9 @@ projects[search_api][version] = "1.6"
 ; Search API Attachments
 ;projects[search_api_attachments][version] = "1.2"
 
+; Search API Pages
+;projects[search_api_page] = "1.0-beta2"
+
 ; Search API Solr
 projects[search_api_solr][version] = "1.0-rc5"
 

--- a/os_project/solr.make
+++ b/os_project/solr.make
@@ -3,13 +3,13 @@ core = "7.x"
 api = 2
 
 ; Facet API
-projects[facetapi][version] = "1.3"
+;projects[facetapi][version] = "1.3"
 
 ; Search API
 projects[search_api][version] = "1.6"
 
-; Search API attachments
-projects[search_api_attachments][version] = "1.2"
+; Search API Attachments
+;projects[search_api_attachments][version] = "1.2"
 
 ; Search API Solr
 projects[search_api_solr][version] = "1.0-rc5"

--- a/os_project/solr.make
+++ b/os_project/solr.make
@@ -1,0 +1,16 @@
+; Base Solr search module set
+core = "7.x"
+api = 2
+
+; Facet API
+projects[facetapi][version] = "1.3"
+
+; Search API
+projects[search_api][version] = "1.6"
+
+; Search API attachments
+projects[search_api_attachments][version] = "1.2"
+
+; Search API Solr
+projects[search_api_solr][version] = "1.0-rc5"
+

--- a/os_project/solr.make
+++ b/os_project/solr.make
@@ -5,6 +5,7 @@ api = 2
 ; Facet API
 ;projects[facetapi][version] = "1.3"
 
+
 ; Search API
 projects[search_api][version] = "1.6"
 
@@ -17,3 +18,12 @@ projects[search_api][version] = "1.6"
 ; Search API Solr
 projects[search_api_solr][version] = "1.0-rc5"
 
+
+; ApacheSolr
+;projects[apachesolr][version] = "1.2"
+
+; ApacheSolr Attachments
+;projects[apachesolr_attachments][version] = "1.2"
+
+; ApacheSolr Views
+;projects[apachesolr_views][version] = "1.0-beta2"


### PR DESCRIPTION
A couple issues with the apachesolr stub in os_project.make:
1. It's enabled by default, but many (likely a majority) of projects don't require solr
2. Out of the last 4 projects that have used Solr, all have used the Search API implementation

This change removes the apachesolr stub and puts the standard search api, search api solr, search api attachments and facet api module set into a solr include.
