### PR TITLE
update os_base to 7.x-2.x branch

### DIFF
--- a/os_project/os_project.make
+++ b/os_project/os_project.make
@@ -34,8 +34,8 @@ projects[os_base][subdir] = "stock"
 projects[os_base][type] = "module"
 projects[os_base][download][type] = "git"
 projects[os_base][download][url] = "git://github.com/opensourcery/os_base.git"
-projects[os_base][download][branch] = "7.x-1.x"
-projects[os_base][download][tag] = "7.x-1.0"
+projects[os_base][download][branch] = "7.x-2.x"
+projects[os_base][download][revision] = "b9ac843dac"
 
 ; Follow
 projects[follow][version] = "2.0-alpha1"


### PR DESCRIPTION
I've created a 7.x-2.x version of os_base (https://github.com/opensourcery/os_base/tree/7.x-2.x). Please review and test that first, then if things are good, make a note here and we can update turnip to look at it.  This is sort of an intermediary step prior to moving os_base into turnip.
