### PR TITLE
OS-ACE Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ development. Each site is built as an installation profile.
 
    All changes can then quickly be added via `git add -A`.
 
+1. Instantiate the subtheme. Note that this will perform an initial run of the build script. You'll have OpenSourcery's `Arcturus` Aurora subtheme flavor spun up in your theme directory:
+
+  ```bash
+  bin/init-subtheme
+  ```
+
 1. Customize `my_profile/my_profile.make`
 1. Run `bin/install` for local development
 1. To avoid having to redeclare your default origin each time you pull or push, run your first push as:
@@ -58,6 +64,7 @@ There are several bundled make files:
 * `base.make` - common modules and libraries
 * `images.make` - Media module and other image-related modules
 * `panels.make` - Panels modules related dependencies
+* `theme.make` - Dependencies for Arcturus/Aurora subthemes.
 
 If using dev versions of modules, specific commit hashes are
 preferable in the make files, rather than the more general dev branch.

--- a/bin/init-theme
+++ b/bin/init-theme
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+#
+# This script initializes an Arcturus subtheme.
+#
+# You must have the OS-ACE ruby gem installed to use this script, i.e. either
+#   gem install compass-aurora-os
+# -- OR --
+#   gem update compass-aurora-os
+# before running this script.
+#
+# Then run this from the project root.
+#
+
+BASE_DIR=$(pwd)
+
+## Include config so we have the params to init.
+source bin/.config
+
+## Set BUILD=0 to prevent rebuild. Should be set to BUILD=1 on intial run.
+BUILD=1
+if [[ $BUILD = 1 ]]; then
+  # Run the rebuild script.
+  bin/rebuild
+fi
+
+##
+## Create symlinks for Bedrock defalt layouts.
+##
+
+## @TODO: make this a dynamic list
+LAYOUTS="adakite
+andesite
+basalt
+coal
+flint
+granite
+hawaiite
+obsidian
+pumice
+quartz
+variolite"
+
+## Make the symlinks for layout defaults.
+BEDROCK_PATH="$PROFILE/modules/contrib/bedrock"
+THEME_PATH="$PROFILE/themes/custom/$THEME"
+for layout in $LAYOUTS; do
+  cd $BASE_DIR
+  if [ -d $BEDROCK_PATH ]; then
+    LAYOUT_DIR="$THEME_PATH/sass/partials/layouts/$layout"
+    mkdir -p "$LAYOUT_DIR"
+    cd "$LAYOUT_DIR"
+    ln -s "../../../../../../../modules/contrib/bedrock/plugins/layouts/$layout/sass/partials/_$layout.scss" "_$layout.scss"
+  fi
+done
+cd "$BASE_DIR"
+
+##
+## Since compass doesn't yet have multiple image paths for vendor/app overrides,
+## we hackily symlink the to the icon directory in alphecaa from our image
+## directory.
+##
+## @see https://github.com/chriseppstein/compass/issues/1286
+##
+IMG_PATH="$THEME_PATH/images"
+mkdir -p "$IMG_PATH"
+cd "$IMG_PATH"
+ln -s ../vendor/alphecca/images/icons icons
+cd "$BASE_DIR"
+
+##
+## Initialize theme using OS-ACE
+##
+cd "$PROFILE/themes/custom"
+compass create "$THEME" -r aurora-os --using aurora-os/arcturus \
+--css-dir=css \
+--javascripts-dir=js \
+--fonts-dir=fonts \
+--images-dir=images
+cd "$THEME"
+bundle install


### PR DESCRIPTION
First swing at getting OS-ACE involved with spinning up sites. I've tested this as far as pulling down Turnip, generating the install profile, spinning up the theme, installing the site, logging in, choosing the newly generated theme as default. There are no errors, the site loads normally, and it looks like we have the base css from alphecca/bedrock. From that point it looks like we could probably use some default panels config cause there's nothing on the page except for a not found message and a link.

In any case, further testing in other peeps' environments would probably be good to make sure nothing is awry in the basic workflow of generating a Turnip site utilizing OS-ACE. Also, i didn't add the Grunt integration to this version of things, as I'm not sure who besides me wants to use it.

So, at this point it's really just evaluating whether or not Turnip still works as expected with the integration, and deciding if we need more initial config to make it useful. The Grunt integration would also be another thing to decide on as well.

Please test. 
