### PR TITLE
Allow individual projects and libraries to be built by bin/rebuild

### DIFF
--- a/bin/rebuild
+++ b/bin/rebuild
@@ -45,6 +45,9 @@ for i in "$@"; do
     --compass=*)
     compass="${i#*=}"
     ;;
+    --projects=*)
+    projects="${i#*=}"
+    ;;
     --no-backup)
     no_backup=1
     ;;
@@ -57,6 +60,15 @@ for i in "$@"; do
     ;;
   esac
 done
+
+# If the --projects flag is specified, only build these projects.
+echo "$projects"
+if [ -n "$projects" ]; then
+  echo "Building only these projects from your make file: $projects"
+  drush make $drush --yes --contrib-destination=$PROFILE  --no-core --projects=$projects -y $2 $PROFILE/$PROFILE.make
+  echo "success"
+  exit
+fi
 
 # Remove contrib directories
 DIRECTORIES="drupal

--- a/bin/rebuild
+++ b/bin/rebuild
@@ -66,19 +66,16 @@ done
 
 # If the --projects or --libraries flags were specified, then only
 # build the specified projects and/or libraries.
-echo "PROJECTS: $projects"
-echo "LIBRARIES: $libraries"
-if [ -n "$projects" ] || [-n "$projects"]; then
+if [ -n "$projects" ] || [ -n "$libraries" ]; then
   echo "Limiting build to specified packages..."
-  packages="";
-  if [-n "$projects ]; then
-    packages="--projects=$projects"
+  if [ -n "$projects" ]; then
+    proj="--projects=$projects"
   fi
   if [ -n "$libraries" ]; then
-    packages="$packages --libraries=$libaries"
+    lib="--libraries=$libraries"
   fi
-  drush make $drush --contrib-destination=$PROFILE --no-core -y $packages $PROFILE/$PROFILE.make
-  echo "success"
+  drush make $drush --contrib-destination=$PROFILE --no-core -y $proj $lib $PROFILE/$PROFILE.make
+  echo "Package rebuild succeeded."
   exit
 fi
 

--- a/bin/rebuild
+++ b/bin/rebuild
@@ -48,6 +48,9 @@ for i in "$@"; do
     --projects=*)
     projects="${i#*=}"
     ;;
+    --libraries=*)
+    libraries="${i#*=}"
+    ;;
     --no-backup)
     no_backup=1
     ;;
@@ -61,11 +64,20 @@ for i in "$@"; do
   esac
 done
 
-# If the --projects flag is specified, only build these projects.
-echo "$projects"
-if [ -n "$projects" ]; then
-  echo "Building only these projects from your make file: $projects"
-  drush make $drush --yes --contrib-destination=$PROFILE  --no-core --projects=$projects -y $2 $PROFILE/$PROFILE.make
+# If the --projects or --libraries flags were specified, then only
+# build the specified projects and/or libraries.
+echo "PROJECTS: $projects"
+echo "LIBRARIES: $libraries"
+if [ -n "$projects" ] || [-n "$projects"]; then
+  echo "Limiting build to specified packages..."
+  packages="";
+  if [-n "$projects ]; then
+    packages="--projects=$projects"
+  fi
+  if [ -n "$libraries" ]; then
+    packages="$packages --libraries=$libaries"
+  fi
+  drush make $drush --contrib-destination=$PROFILE --no-core -y $packages $PROFILE/$PROFILE.make
   echo "success"
   exit
 fi


### PR DESCRIPTION
This adds both `--projects` and `--libraries` support for `bin/rebuild`, which is just a simple extension of the pull request from here: https://github.com/opensourcery/turnip/pull/59. 
