### PR TITLE
Resolve http.conf creation error in Puppet.

### DIFF
--- a/manifests/webserver.pp
+++ b/manifests/webserver.pp
@@ -62,8 +62,13 @@ exec { "install-drush":
     require => Package["php-pear"],
 }
 
-file { '/etc/apache2/httpd.conf':
-  ensure => file,
+file { "/etc/apache2":
+  ensure => directory,
+  before => File['/etc/apache2/httpd.conf'],
+}
+
+file { "/etc/apache2/httpd.conf":
+  ensure => present,
   owner  => 'root',
   group  => 'root',
   mode   => '0644',


### PR DESCRIPTION
Sorry, didn't realize this error was being thrown. This ensures that Puppet creates the directory for httpd.conf before it tries to write to the file. Silly. 
