### PR TITLE
Install curl upon vagrant up.

### DIFF
--- a/manifests/webserver.pp
+++ b/manifests/webserver.pp
@@ -16,6 +16,7 @@ package { "mysql-server": }
 # Required for drush make
 package { "zip": }
 package { "git": }
+package { "curl": }
 # Developer Tools
 package { "vim": }
 


### PR DESCRIPTION
Curl is required for installing Composer, which happens during install script.
