### PR TITLE
reserve uids 2-9 for testing/QA user accounts

### DIFF
--- a/os_project/os_project.info
+++ b/os_project/os_project.info
@@ -51,11 +51,65 @@ dependencies[] = os_base
 ;
 ; Users
 ;
+; "Super User" administrator account.
 users[admin][uid] = 1
 users[admin][name] = admin
 users[admin][mail] = admin@os_project.example.com
 users[admin][status] = 1
 users[admin][data][overlay] = 0
+users[admin][roles] = administrator
+
+;
+; Reserve a handfull of testing accounts.
+; As the project develops, configure these accounts to facilitate QA/testing.
+;
+users[test_two][uid] = 2
+users[test_two][name] = test_two
+users[test_two][mail] = test_two@os_project.example.com
+users[test_two][status] = 0
+users[test_two][data][overlay] = 0
+
+users[test_three][uid] = 3
+users[test_three][name] = test_three
+users[test_three][mail] = test_three@os_project.example.com
+users[test_three][status] = 0
+users[test_three][data][overlay] = 0
+
+users[test_four][uid] = 4
+users[test_four][name] = test_four
+users[test_four][mail] = test_four@os_project.example.com
+users[test_four][status] = 0
+users[test_four][data][overlay] = 0
+
+users[test_five][uid] = 5
+users[test_five][name] = test_five
+users[test_five][mail] = test_five@os_project.example.com
+users[test_five][status] = 0
+users[test_five][data][overlay] = 0
+
+users[test_six][uid] = 6
+users[test_six][name] = test_six
+users[test_six][mail] = test_six@os_project.example.com
+users[test_six][status] = 0
+users[test_six][data][overlay] = 0
+
+users[test_seven][uid] = 7
+users[test_seven][name] = test_seven
+users[test_seven][mail] = test_seven@os_project.example.com
+users[test_seven][status] = 0
+users[test_seven][data][overlay] = 0
+
+users[test_eight][uid] = 8
+users[test_eight][name] = test_eight
+users[test_eight][mail] = test_eight@os_project.example.com
+users[test_eight][status] = 0
+users[test_eight][data][overlay] = 0
+
+users[test_nine][uid] = 9
+users[test_nine][name] = test_nine
+users[test_nine][mail] = test_nine@os_project.example.com
+users[test_nine][status] = 0
+users[test_nine][data][overlay] = 0
 
 ;
 ; Variables

--- a/os_project/os_project.info
+++ b/os_project/os_project.info
@@ -153,6 +153,7 @@ profiles/os_project/libraries/superfish/supposition.js
 profiles/os_project/libraries/superfish/sftouchscreen.js
 profiles/os_project/libraries/superfish/sfsmallscreen.js"
 
+
 ;
 ; Nodes
 ;

--- a/os_project/os_project.info
+++ b/os_project/os_project.info
@@ -62,6 +62,7 @@ users[admin][roles] = administrator
 ;
 ; Reserve a handfull of testing accounts.
 ; As the project develops, configure these accounts to facilitate QA/testing.
+; Delete them after the site launches or if they become unnecessary.
 ;
 users[test_two][uid] = 2
 users[test_two][name] = test_two
@@ -152,7 +153,6 @@ profiles/os_project/libraries/superfish/supersubs.js
 profiles/os_project/libraries/superfish/supposition.js
 profiles/os_project/libraries/superfish/sftouchscreen.js
 profiles/os_project/libraries/superfish/sfsmallscreen.js"
-
 
 ;
 ; Nodes


### PR DESCRIPTION
A more complex site should be thoroughly tested from each possible user's perspective. Single digit uids are easier to remember for testing specific user roles or combinations of roles. Depending on project needs these accounts could even be configured with memorable dummy content to make QA more fun, easier and therefore more productive! Ideally QA and demos should never involve the constant re-creation of user accounts. (Unless the feature tested is the creation of user accounts :-)

This also gives the admin user the administrator role. (This fixes issues where custom code or page_manager access checks specifically look for the administrator user role.)
