### PR TITLE
Environment indicator replacement

### DIFF
--- a/bin/deploy_to_test
+++ b/bin/deploy_to_test
@@ -121,11 +121,11 @@ drush @$SUBDOMAIN fra -y
 # Clear caches.
 drush @$SUBDOMAIN cc all
 
-# Enable the environment indicator module.
-echo "Enabling environment indicator module."
-drush @$SUBDOMAIN en -y environment_indicator
-drush @$SUBDOMAIN role-add-perm "anonymous user" "access environment indicator"
-drush @$SUBDOMAIN role-add-perm "authenticated user" "access environment indicator"
+# Enable the which_environment module.
+echo "Enabling which_environment module."
+drush @$SUBDOMAIN en -y which_environment
+drush @$SUBDOMAIN role-add-perm "anonymous user" "view which environment"
+drush @$SUBDOMAIN role-add-perm "authenticated user" "view which environment"
 
 # Enable stage file proxy module.
 if [ "$PRODUCTIONURL" != "http://" ]; then

--- a/os_project/base.make
+++ b/os_project/base.make
@@ -100,9 +100,6 @@ projects[admin_menu][version] = "3.0-rc4"
 projects[devel][subdir] = "development"
 projects[devel][version] = "1.5"
 
-projects[environment_indicator][subdir] = "development"
-projects[environment_indicator][version] = "2.5"
-
 projects[maillog][download][branch] = "7.x-1.x"
 projects[maillog][download][revision] = "2591153"
 projects[maillog][subdir] = "development"
@@ -128,6 +125,9 @@ projects[stage_file_proxy][version] = "1.6"
 projects[styleguide][subdir] = "development"
 projects[styleguide][version] = "1.1"
 projects[styleguide][patch][] = "https://drupal.org/files/issues/1004246-9-styleguide-maintenance-page.patch"
+
+; Which Environment?
+projects[which_environment][version] = "1.1"
 
 projects[diff][subdir] = "development"
 projects[diff][version] = "3.2"

--- a/shared/settings.local.php.example
+++ b/shared/settings.local.php.example
@@ -36,9 +36,10 @@ $conf['stage_file_proxy_origin_dir'] = 'sites/default/files';
 // See http://drupal.stackexchange.com/questions/63226/drupal-7-20-image-styles-return-a-url-with-access-denied
 $conf['image_allow_insecure_derivatives'] = TRUE;
 
-// Environment indicator
-$conf['environment_indicator_text'] = 'LOCAL DEV';
-$conf['environment_indicator_color'] = 'green';
+// Which Environment
+$conf['which_environment'] = array(
+  'type' => 'Local Dev',
+);
 
 // Views.
 $conf['views_ui_show_sql_query'] = 1;


### PR DESCRIPTION
Note that we still need to add the `settings.local.php` environment title `$conf` setting on each of our hosts that intend to use it. I was thinking we could easily patch the module to add a `color` key to the settings array so we can color per environment. This is a start towards keeping it simple.
